### PR TITLE
fix: inability to trigger snippets in the middle of a line

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -78,6 +78,25 @@ func (d textDocument) getLine(linenum int) (string, bool) {
 	return d.lines[linenum], true
 }
 
+func (d textDocument) getCompletionCandidate(linenum, colnum int) (string, bool) {
+	line, found := d.getLine(linenum)
+	if !found {
+		return "", false
+	}
+	if colnum > len(line) {
+		return "", false
+	}
+	line = line[:colnum]
+	index := strings.LastIndexAny(line, " 	")
+	if index == -1 {
+		return line, true
+	}
+	if index == len(line) - 1 {
+		return "", false
+	}
+	return line[index+1:], true
+}
+
 func stringLines(s string) []string {
 	return strings.Split(s, "\n")
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -194,14 +194,13 @@ func (s *Server) handleRequest(m types.RequestMessage) error {
 			return nil
 		}
 
-		line, ok := doc.getLine(params.Position.Line)
+		candidate, ok := doc.getCompletionCandidate(params.Position.Line, params.Position.Character)
 		if !ok {
 			s.sendResponse(m.ID, nil)
 			return nil
 		}
 
-		line = strings.TrimSpace(line)
-		snippets := s.snippets.Search(params.TextDocument.URI, line)
+		snippets := s.snippets.Search(params.TextDocument.URI, candidate)
 
 		items := []types.CompletionItem{}
 		for _, sn := range snippets {


### PR DESCRIPTION
Thank you for this awesome program. Thought I could help contribute. Currently snippetls does not trigger snippets past the first whitespaces characters except for the whitespace characters that occur at the beginning of a line. That is to say if I have snippet trigger **if** then if will not trigger if I write **let something = if**. Now **if** can trigger anywhere not merely if it occurs at the start of a line or immediately after leading whitespace. Will be quite busy so might not have time to respond back promptly. Thank you!